### PR TITLE
adjust api response for omdb fetch

### DIFF
--- a/dist/osu-expertplus.user.js
+++ b/dist/osu-expertplus.user.js
@@ -942,10 +942,10 @@ OsuExpertPlus.omdb = (() => {
     } catch {
       throw new Error(MSG_BEATMAPSET_RESPONSE_UNEXPECTED);
     }
-    if (!Array.isArray(data)) {
+    if (!Array.isArray(data.Difficulties)) {
       throw new Error(MSG_BEATMAPSET_RESPONSE_UNEXPECTED);
     }
-    return data;
+    return data.Difficulties;
   }
 
   /**

--- a/src/utils/omdb.js
+++ b/src/utils/omdb.js
@@ -47,10 +47,10 @@ OsuExpertPlus.omdb = (() => {
     } catch {
       throw new Error(MSG_BEATMAPSET_RESPONSE_UNEXPECTED);
     }
-    if (!Array.isArray(data)) {
+    if (!Array.isArray(data.Difficulties)) {
       throw new Error(MSG_BEATMAPSET_RESPONSE_UNEXPECTED);
     }
-    return data;
+    return data.Difficulties;
   }
 
   /**


### PR DESCRIPTION
omdb is back, and it seems like they changed the api response so it doesnt return a raw array anymore. the original function expects to return an array of objects as per jsdoc specification. this pr returns the `Difficulties` array instead of the entire response (minimal api changes)
```js
// https://omdb.nyahh.net/api/set/2435345?key=***

{
    "SetID": "2435345",
    "Artist": "Silentroom",
    "Title": "F1055",
    "Nominators": [
        {
            "UserID": 2043401,
            "Username": "Enon"
        },
        {
            "UserID": 12157130,
            "Username": "Wanpachi"
        }
    ],
    "Difficulties": [
        {
            "BeatmapID": 5308445,
            "Difficulty": "final",
            "ChartRank": 639,
            "ChartYearRank": 8,
            "RatingCount": 59,
            "WeightedAvg": 3.62924,
            "OwnRating": null,
            "Ratings": {
                "0.0": 2,
                "0.5": 1,
                "1.0": 2,
                "1.5": 3,
                "2.5": 1,
                "3.0": 5,
                "3.5": 11,
                "4.0": 13,
                "4.5": 7,
                "5.0": 14
            },
            "Descriptors": "17, 19, 25, 27, 50"
        },
        // ...
    ]
}
```

no version bump. leaving it to you